### PR TITLE
Update Caesium to time.0xt.ca

### DIFF
--- a/ecosystem.json
+++ b/ecosystem.json
@@ -1,17 +1,6 @@
 {
   "servers": [
     {
-      "name": "Caesium",
-      "publicKeyType": "ed25519",
-      "publicKey": "iBVjxg/1j7y1+kQUTBYdTabxCppesU/07D4PMDJk2WA=",
-      "addresses": [
-        {
-          "protocol": "udp",
-          "address": "caesium.tannerryan.ca:2002"
-        }
-      ]
-    },
-    {
       "name": "Chainpoint-Roughtime",
       "publicKeyType": "ed25519",
       "publicKey": "bbT+RPS7zKX6w71ssPibzmwWqU9ffRV5oj2OresSmhE=",
@@ -63,6 +52,17 @@
         {
           "protocol": "udp",
           "address": "ticktock.mixmin.net:5333"
+        }
+      ]
+    },
+    {
+      "name": "time.0xt.ca",
+      "publicKeyType": "ed25519",
+      "publicKey": "iBVjxg/1j7y1+kQUTBYdTabxCppesU/07D4PMDJk2WA=",
+      "addresses": [
+        {
+          "protocol": "udp",
+          "address": "time.0xt.ca:2002"
         }
       ]
     }

--- a/ecosystem.json.go
+++ b/ecosystem.json.go
@@ -8,17 +8,6 @@ import (
 
 var Ecosystem = []config.Server{
 	{
-		Name:          "Caesium",
-		PublicKeyType: "ed25519",
-		PublicKey:     []byte{136, 21, 99, 198, 15, 245, 143, 188, 181, 250, 68, 20, 76, 22, 29, 77, 166, 241, 10, 154, 94, 177, 79, 244, 236, 62, 15, 48, 50, 100, 217, 96},
-		Addresses: []config.ServerAddress{
-			{
-				Protocol: "udp",
-				Address:  "caesium.tannerryan.ca:2002",
-			},
-		},
-	},
-	{
 		Name:          "Chainpoint-Roughtime",
 		PublicKeyType: "ed25519",
 		PublicKey:     []byte{109, 180, 254, 68, 244, 187, 204, 165, 250, 195, 189, 108, 176, 248, 155, 206, 108, 22, 169, 79, 95, 125, 21, 121, 162, 61, 142, 173, 235, 18, 154, 17},
@@ -70,6 +59,17 @@ var Ecosystem = []config.Server{
 			{
 				Protocol: "udp",
 				Address:  "ticktock.mixmin.net:5333",
+			},
+		},
+	},
+	{
+		Name:          "time.0xt.ca",
+		PublicKeyType: "ed25519",
+		PublicKey:     []byte{136, 21, 99, 198, 15, 245, 143, 188, 181, 250, 68, 20, 76, 22, 29, 77, 166, 241, 10, 154, 94, 177, 79, 244, 236, 62, 15, 48, 50, 100, 217, 96},
+		Addresses: []config.ServerAddress{
+			{
+				Protocol: "udp",
+				Address:  "time.0xt.ca:2002",
 			},
 		},
 	},

--- a/ecosystem.md
+++ b/ecosystem.md
@@ -6,34 +6,6 @@ provisioned. Refer to `README.md` for information about adding your server to
 the list.
 
 
-## Caesium
-
-[Caesium](https://caesium.tannerryan.ca), aptly named after the element defining
-a second, runs on a stratum 2 NTP server hosted in Toronto, Canada. 
-
-The clock is synchronized with authenticated NTP connections to NIST (National
-Institute of Standards and Technology) and the Canadian equivalent: NRC
-(National Research Council Canada), which are both directly connected to atomic
-clocks (caesium fountains and/or hydrogen masers). There are also multiple
-unauthenticated stratum 1 upstreams, maintained by GNSS (GPS + Galileo +
-GLONASS). The accuracy is typically better than +/- 30 microseconds.
-
-The Roughtime service is accessible at `caesium.tannerryan.ca:2002`. The public
-key may be found on Caesium's [website](https://caesium.tannerryan.ca), or
-through a DNS TXT lookup.
-
-```
-dig TXT caesium.tannerryan.ca +short
-```
-
-The Roughtime service is powered by Google's [Go reference
-implementation](https://roughtime.googlesource.com/roughtime/).
-
-No uptime is guaranteed, but the server is constantly monitored for accuracy and
-availability. From time to time, there may be a few minutes of downtime for
-server maintenance.
-
-
 ## Chainpoint-Roughtime
 
 The [Chainpoint](https://chainpoint.org) Roughtime service is hosted
@@ -105,3 +77,31 @@ written in Go and is compiled locally on the Raspberry Pi.  The Roughtime
 server was announced on the mailing list, archived
 [here](https://groups.google.com/a/chromium.org/forum/#!topic/proto-roughtime/7PApRXJ-x0Y).
 The announcement includes the server details.
+
+
+## time.0xt.ca
+
+[time.0xt.ca](https://time.0xt.ca) runs on a stratum 2 NTP server hosted in
+Toronto, Canada. 
+
+The clock is synchronized with authenticated NTP connections to NIST (National
+Institute of Standards and Technology), and the Canadian equivalent, NRC
+(National Research Council Canada), which are both directly connected to atomic
+sources (caesium fountains and/or hydrogen masers). There are also multiple
+unauthenticated stratum 1 upstreams, maintained by GNSS (GPS + Galileo +
+GLONASS). The accuracy is typically within +/- 30 microseconds.
+
+The Roughtime service is accessible at `time.0xt.ca:2002`. The public key is
+available on time.0xt.ca's [website](https://time.0xt.ca), or through a DNS TXT
+lookup.
+
+```
+dig TXT time.0xt.ca +short
+```
+
+The Roughtime service is powered by Google's [Go reference
+implementation](https://roughtime.googlesource.com/roughtime/).
+
+No uptime is guaranteed, but the server is constantly monitored for accuracy and
+availability. From time to time, there may be a few minutes of downtime for
+server maintenance.


### PR DESCRIPTION
The domain has been changed from [caesium.tannerryan.ca:2002](https://caesium.tannerryan.ca) to [time.0xt.ca:2002](https://time.0xt.ca). All keys remain the same.

A `CNAME` record has been created for clients using the previous domain. This record will stay in place for at least 1 year.