### PR TITLE
add support for Windows

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloudflare/roughtime
 
-go 1.13
+go 1.19
 
 require (
 	golang.org/x/crypto v0.1.0

--- a/mjd/mjd_unix.go
+++ b/mjd/mjd_unix.go
@@ -1,3 +1,6 @@
+//go:build unix
+// +build unix
+
 package mjd
 
 import (

--- a/mjd/mjd_windows.go
+++ b/mjd/mjd_windows.go
@@ -1,0 +1,20 @@
+//go:build windows
+// +build windows
+
+package mjd
+
+import (
+	"golang.org/x/sys/windows"
+)
+
+func Now() Mjd {
+	fileTime := windows.Filetime{}
+	windows.GetSystemTimeAsFileTime(&fileTime)
+	ns := fileTime.Nanoseconds()
+	daysPostEpoch := ns / 1e9 / secs_per_day
+	retval := Mjd{
+		day: unix_epoch + uint64(daysPostEpoch),
+		µs:  float64(ns/1e3 - daysPostEpoch*secs_per_day*1e6),
+	}
+	return retval
+}


### PR DESCRIPTION
Package `mjd` originally only have support for unix-like OSes. This PR adds support for Windows.

Notes:
- the `unix` build tag is added [since Golang 1.19](https://github.com/golang/go/issues/20322); if legacy Golang compatibility is still required, we can work around it with more complex build tags