### PR TITLE
Update time.0xt.ca to time.txryan.com

### DIFF
--- a/ecosystem.json
+++ b/ecosystem.json
@@ -56,13 +56,13 @@
       ]
     },
     {
-      "name": "time.0xt.ca",
+      "name": "time.txryan.com",
       "publicKeyType": "ed25519",
       "publicKey": "iBVjxg/1j7y1+kQUTBYdTabxCppesU/07D4PMDJk2WA=",
       "addresses": [
         {
           "protocol": "udp",
-          "address": "time.0xt.ca:2002"
+          "address": "time.txryan.com:2002"
         }
       ]
     }

--- a/ecosystem.json.go
+++ b/ecosystem.json.go
@@ -63,13 +63,13 @@ var Ecosystem = []config.Server{
 		},
 	},
 	{
-		Name:          "time.0xt.ca",
+		Name:          "time.txryan.com",
 		PublicKeyType: "ed25519",
 		PublicKey:     []byte{136, 21, 99, 198, 15, 245, 143, 188, 181, 250, 68, 20, 76, 22, 29, 77, 166, 241, 10, 154, 94, 177, 79, 244, 236, 62, 15, 48, 50, 100, 217, 96},
 		Addresses: []config.ServerAddress{
 			{
 				Protocol: "udp",
-				Address:  "time.0xt.ca:2002",
+				Address:  "time.txryan.com:2002",
 			},
 		},
 	},

--- a/ecosystem.md
+++ b/ecosystem.md
@@ -79,24 +79,23 @@ server was announced on the mailing list, archived
 The announcement includes the server details.
 
 
-## time.0xt.ca
+## time.txryan.com
 
-[time.0xt.ca](https://time.0xt.ca) runs on a stratum 2 NTP server hosted in
-Toronto, Canada. 
+[time.txryan.com](https://time.txryan.com) runs on a stratum 2 NTP server.
 
 The clock is synchronized with authenticated NTP connections to NIST (National
 Institute of Standards and Technology), and the Canadian equivalent, NRC
 (National Research Council Canada), which are both directly connected to atomic
 sources (caesium fountains and/or hydrogen masers). There are also multiple
 unauthenticated stratum 1 upstreams, maintained by GNSS (GPS + Galileo +
-GLONASS). The accuracy is typically within +/- 30 microseconds.
+GLONASS). The accuracy is typically within +/- 50 microseconds.
 
-The Roughtime service is accessible at `time.0xt.ca:2002`. The public key is
-available on time.0xt.ca's [website](https://time.0xt.ca), or through a DNS TXT
-lookup.
+The Roughtime service is accessible at `time.txryan.com:2002`. The public key is
+available on time.txryan.com's [website](https://time.txryan.com), or through a
+DNS TXT lookup.
 
 ```
-dig TXT time.0xt.ca +short
+dig TXT time.txryan.com +short
 ```
 
 The Roughtime service is powered by Google's [Go reference


### PR DESCRIPTION
Changes:
- Update `time.0xt.ca` references to `time.txryan.com`
- Reduce estimated server precision from ± 30μs to ± 50μs

Closes #35 