### PR TITLE
Prune unreachable servers from ecosystem.json

### DIFF
--- a/ecosystem.json
+++ b/ecosystem.json
@@ -1,18 +1,8 @@
 {
   "servers": [
     {
-      "name": "Chainpoint-Roughtime",
-      "publicKeyType": "ed25519",
-      "publicKey": "bbT+RPS7zKX6w71ssPibzmwWqU9ffRV5oj2OresSmhE=",
-      "addresses": [
-        {
-          "protocol": "udp",
-          "address": "roughtime.chainpoint.org:2002"
-        }
-      ]
-    },
-    {
         "name": "Cloudflare-Roughtime-2",
+        "version": "IETF-Roughtime",
         "publicKeyType": "ed25519",
         "publicKey": "0GD7c3yP8xEc4Zl2zeuN2SlLvDVVocjsPSL8/Rl/7zg=",
         "addresses": [
@@ -23,18 +13,8 @@
         ]
     },
     {
-      "name": "Google-Sandbox-Roughtime",
-      "publicKeyType": "ed25519",
-      "publicKey": "etPaaIxcBMY1oUeGpwvPMCJMwlRVNxv51KK/tktoJTQ=",
-      "addresses": [
-        {
-          "protocol": "udp",
-          "address": "roughtime.sandbox.google.com:2002"
-        }
-      ]
-    },
-    {
       "name": "int08h-Roughtime",
+      "version": "Google-Roughtime",
       "publicKeyType": "ed25519",
       "publicKey": "AW5uAoTSTDfG5NfY1bTh08GUnOqlRb+HVhbJ3ODJvsE=",
       "addresses": [
@@ -45,18 +25,8 @@
       ]
     },
     {
-      "name": "ticktock",
-      "publicKeyType": "ed25519",
-      "publicKey": "cj8GsiNlRkqiDElAeNMSBBMwrAl15hYPgX50+GWX/lA=",
-      "addresses": [
-        {
-          "protocol": "udp",
-          "address": "ticktock.mixmin.net:5333"
-        }
-      ]
-    },
-    {
       "name": "time.txryan.com",
+      "version": "Google-Roughtime",
       "publicKeyType": "ed25519",
       "publicKey": "iBVjxg/1j7y1+kQUTBYdTabxCppesU/07D4PMDJk2WA=",
       "addresses": [

--- a/ecosystem.json.go
+++ b/ecosystem.json.go
@@ -6,18 +6,8 @@ import "github.com/cloudflare/roughtime/config"
 
 var Ecosystem = []config.Server{
 	{
-		Name:          "Chainpoint-Roughtime",
-		PublicKeyType: "ed25519",
-		PublicKey:     []byte{109, 180, 254, 68, 244, 187, 204, 165, 250, 195, 189, 108, 176, 248, 155, 206, 108, 22, 169, 79, 95, 125, 21, 121, 162, 61, 142, 173, 235, 18, 154, 17},
-		Addresses: []config.ServerAddress{
-			{
-				Protocol: "udp",
-				Address:  "roughtime.chainpoint.org:2002",
-			},
-		},
-	},
-	{
 		Name:          "Cloudflare-Roughtime-2",
+		Version:       "IETF-Roughtime",
 		PublicKeyType: "ed25519",
 		PublicKey:     []byte{208, 96, 251, 115, 124, 143, 243, 17, 28, 225, 153, 118, 205, 235, 141, 217, 41, 75, 188, 53, 85, 161, 200, 236, 61, 34, 252, 253, 25, 127, 239, 56},
 		Addresses: []config.ServerAddress{
@@ -28,18 +18,8 @@ var Ecosystem = []config.Server{
 		},
 	},
 	{
-		Name:          "Google-Sandbox-Roughtime",
-		PublicKeyType: "ed25519",
-		PublicKey:     []byte{122, 211, 218, 104, 140, 92, 4, 198, 53, 161, 71, 134, 167, 11, 207, 48, 34, 76, 194, 84, 85, 55, 27, 249, 212, 162, 191, 182, 75, 104, 37, 52},
-		Addresses: []config.ServerAddress{
-			{
-				Protocol: "udp",
-				Address:  "roughtime.sandbox.google.com:2002",
-			},
-		},
-	},
-	{
 		Name:          "int08h-Roughtime",
+		Version:       "Google-Roughtime",
 		PublicKeyType: "ed25519",
 		PublicKey:     []byte{1, 110, 110, 2, 132, 210, 76, 55, 198, 228, 215, 216, 213, 180, 225, 211, 193, 148, 156, 234, 165, 69, 191, 135, 86, 22, 201, 220, 224, 201, 190, 193},
 		Addresses: []config.ServerAddress{
@@ -50,18 +30,8 @@ var Ecosystem = []config.Server{
 		},
 	},
 	{
-		Name:          "ticktock",
-		PublicKeyType: "ed25519",
-		PublicKey:     []byte{114, 63, 6, 178, 35, 101, 70, 74, 162, 12, 73, 64, 120, 211, 18, 4, 19, 48, 172, 9, 117, 230, 22, 15, 129, 126, 116, 248, 101, 151, 254, 80},
-		Addresses: []config.ServerAddress{
-			{
-				Protocol: "udp",
-				Address:  "ticktock.mixmin.net:5333",
-			},
-		},
-	},
-	{
 		Name:          "time.txryan.com",
+		Version:       "Google-Roughtime",
 		PublicKeyType: "ed25519",
 		PublicKey:     []byte{136, 21, 99, 198, 15, 245, 143, 188, 181, 250, 68, 20, 76, 22, 29, 77, 166, 241, 10, 154, 94, 177, 79, 244, 236, 62, 15, 48, 50, 100, 217, 96},
 		Addresses: []config.ServerAddress{

--- a/ecosystem.md
+++ b/ecosystem.md
@@ -6,37 +6,7 @@ provisioned. Refer to `README.md` for information about adding your server to
 the list.
 
 
-## Chainpoint-Roughtime
-
-The [Chainpoint](https://chainpoint.org) Roughtime service is hosted
-at `roughtime.chainpoint.org:2002`. The public key, and information about
-running the Docker container we've created for [roughenough](https://github.com/int08h/roughenough),
-is provided at [https://github.com/chainpoint/chainpoint-roughtime](https://github.com/chainpoint/chainpoint-roughtime).
-
-In addition to the Github repository `README.md`, the long-term public key in
-Hexadecimal form is also provided as a DNS `TXT` record accessible with:
-
-```
-$ dig -t txt roughtime.chainpoint.org
-```
-
-The Chainpoint Roughtime service is in open beta, but aims to operate with
-high-availability. The [roughenough](https://github.com/int08h/roughenough)
-Rust implementation of Roughtime is currently running on two servers in the
-Google Compute Engine cloud (US-EAST4), both synced to Google's internal
-high accuracy NTP service. These servers exist behind a public UDP
-load-balancer and a Cloudflare DNS `A` record.
-
-
-## Cloudflare-Roughtime (**Deprecated**)
-
-
-**Deprecation notice**: The Cloudflare-Roughtime server will be shut down on
-July 1, 2024. Please update your client to use Cloudflare-Roughtime-2 instead.
-
-
 ## Cloudflare-Roughtime-2
-
 
 Cloudflare's Roughtime service aims for high availability and low latency. The
 [announcement](https://blog.cloudflare.com/roughtime/) provides details about
@@ -50,15 +20,6 @@ currently in beta. As such the root key is subject to change. It will be
 updated here and in the [developer
 docs](https://developers.cloudflare.com/time-services/roughtime/recipes/). You
 can also obtain it over DNS; see the docs for details.
-
-
-## Google-Sandbox-Roughtime
-
-This is Google's [proof-of-concept
-server](https://roughtime.googlesource.com/roughtime/#current-state-of-the-project).
-It is experimental and does not, as of yet, provide uptime guarantees. The root
-public key is published
-[here](https://roughtime.googlesource.com/roughtime/+/master/roughtime-servers.json).
 
 
 ## int08h-Roughtime
@@ -76,17 +37,6 @@ The public key is available from the `README.md` in this project,
 a [blog post at int08h](https://int08h.com/post/public-roughtime-server/), 
 and the DNS `TXT` record of `roughtime.int08h.com` (see the 
 [Chainpoint](#chainpoint-roughtime) entry for how to look this up with `dig`).
-
-
-## Mixmin Roughtime
-
-Mixmin's Roughtime service resides on a dedicated Raspberry Pi running Arch
-Linux.  The Pi has an Adafruit GPS module fitted and uses it to sync the system
-clock via NTP.  It uses Adam Langley's reference implementation of Roughtime,
-written in Go and is compiled locally on the Raspberry Pi.  The Roughtime
-server was announced on the mailing list, archived
-[here](https://groups.google.com/a/chromium.org/forum/#!topic/proto-roughtime/7PApRXJ-x0Y).
-The announcement includes the server details.
 
 
 ## time.txryan.com
@@ -114,3 +64,62 @@ implementation](https://roughtime.googlesource.com/roughtime/).
 No uptime is guaranteed, but the server is constantly monitored for accuracy and
 availability. From time to time, there may be a few minutes of downtime for
 server maintenance.
+
+
+## Inactive servers
+
+
+## Chainpoint-Roughtime
+
+**This service is unreachable as of 2024-07-01.**
+
+The [Chainpoint](https://chainpoint.org) Roughtime service is hosted
+at `roughtime.chainpoint.org:2002`. The public key, and information about
+running the Docker container we've created for [roughenough](https://github.com/int08h/roughenough),
+is provided at [https://github.com/chainpoint/chainpoint-roughtime](https://github.com/chainpoint/chainpoint-roughtime).
+
+In addition to the Github repository `README.md`, the long-term public key in
+Hexadecimal form is also provided as a DNS `TXT` record accessible with:
+
+```
+$ dig -t txt roughtime.chainpoint.org
+```
+
+The Chainpoint Roughtime service is in open beta, but aims to operate with
+high-availability. The [roughenough](https://github.com/int08h/roughenough)
+Rust implementation of Roughtime is currently running on two servers in the
+Google Compute Engine cloud (US-EAST4), both synced to Google's internal
+high accuracy NTP service. These servers exist behind a public UDP
+load-balancer and a Cloudflare DNS `A` record.
+
+
+
+### Cloudflare-Roughtime
+
+**Deprecation notice**: The Cloudflare-Roughtime server will be shut down on
+2024-07-01. Please update your client to use Cloudflare-Roughtime-2 instead.
+
+
+## Google-Sandbox-Roughtime
+
+**This service is unreachable as of 2024-07-01.**
+
+This is Google's [proof-of-concept
+server](https://roughtime.googlesource.com/roughtime/#current-state-of-the-project).
+It is experimental and does not, as of yet, provide uptime guarantees. The root
+public key is published
+[here](https://roughtime.googlesource.com/roughtime/+/master/roughtime-servers.json).
+
+
+## Mixmin Roughtime
+
+**This service is unreachable as of 2024-07-01.**
+
+Mixmin's Roughtime service resides on a dedicated Raspberry Pi running Arch
+Linux.  The Pi has an Adafruit GPS module fitted and uses it to sync the system
+clock via NTP.  It uses Adam Langley's reference implementation of Roughtime,
+written in Go and is compiled locally on the Raspberry Pi.  The Roughtime
+server was announced on the mailing list, archived
+[here](https://groups.google.com/a/chromium.org/forum/#!topic/proto-roughtime/7PApRXJ-x0Y).
+The announcement includes the server details.
+

--- a/internal/ecosystem_json_go_builder/main.go
+++ b/internal/ecosystem_json_go_builder/main.go
@@ -52,6 +52,7 @@ func main() {
 	for _, server := range servers {
 		fmt.Fprintf(file, "\t{\n")
 		fmt.Fprintf(file, "\t\tName:          \"%v\",\n", server.Name)
+		fmt.Fprintf(file, "\t\tVersion:       \"%v\",\n", server.Version)
 		fmt.Fprintf(file, "\t\tPublicKeyType: \"%v\",\n", server.PublicKeyType)
 
 		fmt.Fprint(file, "\t\tPublicKey:     []byte{")


### PR DESCRIPTION
Closes #38.

The following servers are unreachable as of today:

- Chainpoint-Roughtime
- Google-Sandbox-Roughtime
- ticktock

Accordingly, remove them the ecosystem.json file.