### PR TITLE
Fix signature of `CreateRequest()`

### DIFF
--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -304,7 +304,7 @@ func handleSRVTag(advertisedPreference []Version) bool {
 // chain, prevReply can be empty. It returns the nonce (needed to verify the
 // reply), the blind (needed to prove correct chaining to an external party)
 // and the request itself.
-func CreateRequest(versionPreference []Version, rand io.Reader, prevReply, rootPublicKey ed25519.PublicKey) (nonce, blind []byte, request []byte, err error) {
+func CreateRequest(versionPreference []Version, rand io.Reader, prevReply []byte, rootPublicKey ed25519.PublicKey) (nonce, blind []byte, request []byte, err error) {
 	advertisedVersions, versionIETF, err := advertisedVersionsFromPreference(versionPreference)
 	if err != nil {
 		return nil, nil, nil, err


### PR DESCRIPTION
Partially addresses #53.

In the previous commit, the type of `prevReply` was erroneusly changed to `ed25519.PublicKey`. The compiler doesn't mind because this type is an alias for `[]byte`.