### PR TITLE
Have `CreateReplies()` check for mismatched server

### DIFF
--- a/cmd/testserver/main.go
+++ b/cmd/testserver/main.go
@@ -115,7 +115,7 @@ func handleRequest(requestBytes []byte, cert *protocol.Certificate, onlineSK ed2
 	}
 
 	// Parse the request and create the response.
-	replies, err := protocol.CreateReplies(responseVer, [][]byte{req.Nonce}, time.Now(), radius, cert)
+	replies, err := protocol.CreateReplies(responseVer, []protocol.Request{*req}, time.Now(), radius, cert)
 	if err != nil {
 		return nil, err
 	}

--- a/protocol/protocol_test.go
+++ b/protocol/protocol_test.go
@@ -545,5 +545,25 @@ func TestSelectCertificateForRequest(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCreateReplyForIncorrectCertificate(t *testing.T) {
+	_, unknownRootPublicKey := createServerIdentity(t)
+	cert, _ := createServerIdentity(t)
+
+	_, _, reqBytes, err := CreateRequest(nil, rand.Reader, nil, unknownRootPublicKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req, err := ParseRequest(reqBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = CreateReplies(VersionDraft11, []Request{*req}, time.Now(), 0, cert)
+	if err == nil {
+		t.Error("expected failure")
+	}
 
 }


### PR DESCRIPTION
The same certificate is used for all requests, so we expect each client to indicate the same server.

This entails a bit of refactoring: instead of passing a list of nonces to `CreateReplies()`, pass the requests themselves.