### PR TITLE
Add roughtime.se to ecosystem.

### DIFF
--- a/ecosystem.json
+++ b/ecosystem.json
@@ -35,6 +35,18 @@
           "address": "time.txryan.com:2002"
         }
       ]
+    },
+    {
+      "name": "roughtime.se",
+      "version": "IETF-Roughtime",
+      "publicKeyType": "ed25519",
+      "publicKey": "S3AzfZJ5CjSdkJ21ZJGbxqdYP/SoE8fXKY0+aicsehI=",
+      "addresses": [
+        {
+          "protocol": "udp",
+          "address": "roughtime.se:2002"
+        }
+      ]
     }
   ]
 }

--- a/ecosystem.json
+++ b/ecosystem.json
@@ -25,18 +25,6 @@
       ]
     },
     {
-      "name": "time.txryan.com",
-      "version": "Google-Roughtime",
-      "publicKeyType": "ed25519",
-      "publicKey": "iBVjxg/1j7y1+kQUTBYdTabxCppesU/07D4PMDJk2WA=",
-      "addresses": [
-        {
-          "protocol": "udp",
-          "address": "time.txryan.com:2002"
-        }
-      ]
-    },
-    {
       "name": "roughtime.se",
       "version": "IETF-Roughtime",
       "publicKeyType": "ed25519",
@@ -45,6 +33,18 @@
         {
           "protocol": "udp",
           "address": "roughtime.se:2002"
+        }
+      ]
+    },
+    {
+      "name": "time.txryan.com",
+      "version": "Google-Roughtime",
+      "publicKeyType": "ed25519",
+      "publicKey": "iBVjxg/1j7y1+kQUTBYdTabxCppesU/07D4PMDJk2WA=",
+      "addresses": [
+        {
+          "protocol": "udp",
+          "address": "time.txryan.com:2002"
         }
       ]
     }

--- a/ecosystem.json.go
+++ b/ecosystem.json.go
@@ -30,18 +30,6 @@ var Ecosystem = []config.Server{
 		},
 	},
 	{
-		Name:          "time.txryan.com",
-		Version:       "Google-Roughtime",
-		PublicKeyType: "ed25519",
-		PublicKey:     []byte{136, 21, 99, 198, 15, 245, 143, 188, 181, 250, 68, 20, 76, 22, 29, 77, 166, 241, 10, 154, 94, 177, 79, 244, 236, 62, 15, 48, 50, 100, 217, 96},
-		Addresses: []config.ServerAddress{
-			{
-				Protocol: "udp",
-				Address:  "time.txryan.com:2002",
-			},
-		},
-	},
-	{
 		Name:          "roughtime.se",
 		Version:       "IETF-Roughtime",
 		PublicKeyType: "ed25519",
@@ -50,6 +38,18 @@ var Ecosystem = []config.Server{
 			{
 				Protocol: "udp",
 				Address:  "roughtime.se:2002",
+			},
+		},
+	},
+	{
+		Name:          "time.txryan.com",
+		Version:       "Google-Roughtime",
+		PublicKeyType: "ed25519",
+		PublicKey:     []byte{136, 21, 99, 198, 15, 245, 143, 188, 181, 250, 68, 20, 76, 22, 29, 77, 166, 241, 10, 154, 94, 177, 79, 244, 236, 62, 15, 48, 50, 100, 217, 96},
+		Addresses: []config.ServerAddress{
+			{
+				Protocol: "udp",
+				Address:  "time.txryan.com:2002",
 			},
 		},
 	},

--- a/ecosystem.json.go
+++ b/ecosystem.json.go
@@ -41,4 +41,16 @@ var Ecosystem = []config.Server{
 			},
 		},
 	},
+	{
+		Name:          "roughtime.se",
+		Version:       "IETF-Roughtime",
+		PublicKeyType: "ed25519",
+		PublicKey:     []byte{75, 112, 51, 125, 146, 121, 10, 52, 157, 144, 157, 181, 100, 145, 155, 198, 167, 88, 63, 244, 168, 19, 199, 215, 41, 141, 62, 106, 39, 44, 122, 18},
+		Addresses: []config.ServerAddress{
+			{
+				Protocol: "udp",
+				Address:  "roughtime.se:2002",
+			},
+		},
+	},
 }

--- a/ecosystem.md
+++ b/ecosystem.md
@@ -49,6 +49,21 @@ and the DNS `TXT` record of `roughtime.int08h.com`:
 $ dig -t txt roughtime.int08h.com
 ```
 
+## roughtime.se
+
+[roughtime.se](https://roughtime.se) provides a stratum 1 Roughtime service. It runs the
+[roughtimed](https://github.com/dansarie/roughtimed) implementation. Hosting is provided by STUPI
+AB. The server is located in Stockholm, Sweden and is directly connected to atomic clocks that track
+the UTC timescale. The aim is for the server to be compatible with the [latest published IETF
+Roughtime draft](https://datatracker.ietf.org/doc/draft-ietf-ntp-roughtime/). The server is
+connected to high-availability power and network infrastructure in a datacenter, however no
+availability is guaranteed. The public key is available on the server's web site, and as a DNS TXT
+record:
+
+```
+dig TXT roughtime.se
+```
+
 ## time.txryan.com
 
 [time.txryan.com](https://time.txryan.com) runs on a stratum 2 NTP server.
@@ -74,18 +89,6 @@ implementation](https://roughtime.googlesource.com/roughtime/).
 No uptime is guaranteed, but the server is constantly monitored for accuracy and
 availability. From time to time, there may be a few minutes of downtime for
 server maintenance.
-
-## roughtime.se
-
-[roughtime.se](https://roughtime.se) provides a stratum 1 Roughtime service. It runs the
-[roughtimed](https://github.com/dansarie/roughtimed) implementation. Hosting is provided by STUPI AB
-and the server is directly connected to atomic clocks that track the UTC timescale. The aim is for
-the server to be compatible with the latest published IETF Roughtime draft. The public key is
-available on the server's web site, and as a DNS TXT record:
-
-```
-dig TXT roughtime.se
-```
 
 ## Inactive servers
 

--- a/ecosystem.md
+++ b/ecosystem.md
@@ -75,6 +75,17 @@ No uptime is guaranteed, but the server is constantly monitored for accuracy and
 availability. From time to time, there may be a few minutes of downtime for
 server maintenance.
 
+## roughtime.se
+
+[roughtime.se](https://roughtime.se) provides a stratum 1 Roughtime service. It runs the
+[roughtimed](https://github.com/dansarie/roughtimed) implementation. Hosting is provided by STUPI AB
+and the server is directly connected to atomic clocks that track the UTC timescale. The aim is for
+the server to be compatible with the latest published IETF Roughtime draft. The public key is
+available on the server's web site, and as a DNS TXT record:
+
+```
+dig TXT roughtime.se
+```
 
 ## Inactive servers
 


### PR DESCRIPTION
This adds [roughtime.se](https://roughtime.se) to the ecosystem.