### PR TITLE
Add roughtime.se to ecosystem.

### DIFF
--- a/ecosystem.json
+++ b/ecosystem.json
@@ -24,6 +24,18 @@
         }
       ]
     },
+   {
+      "name": "roughtime.se",
+      "version": "IETF-Roughtime",
+      "publicKeyType": "ed25519",
+      "publicKey": "S3AzfZJ5CjSdkJ21ZJGbxqdYP/SoE8fXKY0+aicsehI=",
+      "addresses": [
+        {
+          "protocol": "udp",
+          "address": "roughtime.se:2002"
+        }
+      ]
+    },
     {
       "name": "time.txryan.com",
       "version": "Google-Roughtime",

--- a/ecosystem.json.go
+++ b/ecosystem.json.go
@@ -30,6 +30,18 @@ var Ecosystem = []config.Server{
 		},
 	},
 	{
+		Name:          "roughtime.se",
+		Version:       "IETF-Roughtime",
+		PublicKeyType: "ed25519",
+		PublicKey:     []byte{75, 112, 51, 125, 146, 121, 10, 52, 157, 144, 157, 181, 100, 145, 155, 198, 167, 88, 63, 244, 168, 19, 199, 215, 41, 141, 62, 106, 39, 44, 122, 18},
+		Addresses: []config.ServerAddress{
+			{
+				Protocol: "udp",
+				Address:  "roughtime.se:2002",
+			},
+		},
+	},
+	{
 		Name:          "time.txryan.com",
 		Version:       "Google-Roughtime",
 		PublicKeyType: "ed25519",

--- a/ecosystem.md
+++ b/ecosystem.md
@@ -49,6 +49,22 @@ and the DNS `TXT` record of `roughtime.int08h.com`:
 $ dig -t txt roughtime.int08h.com
 ```
 
+## roughtime.se
+
+[roughtime.se](https://roughtime.se) provides a stratum 1 Roughtime service. It
+runs the [roughtimed](https://github.com/dansarie/roughtimed) implementation.
+Hosting is provided by STUPI AB. The server is located in Stockholm, Sweden and
+is directly connected to atomic clocks that track the UTC timescale. The aim is
+for the server to be compatible with the
+[latest published IETF Roughtime draft](https://datatracker.ietf.org/doc/draft-ietf-ntp-roughtime/).
+The server is connected to high-availability power and network infrastructure in
+a datacenter, however no availability is guaranteed. The public key is available
+on the server's web site, and as a DNS TXT record:
+
+```
+dig TXT roughtime.se
+```
+
 ## time.txryan.com
 
 [time.txryan.com](https://time.txryan.com) runs on a stratum 2 NTP server.


### PR DESCRIPTION
Second attempt at adding [roughtime.se](https://roughtime.se/) to the ecosystem after accidentally deleting the head repository for PR #64. Sorry for the confusion!